### PR TITLE
Update version of 'cdap-maven-plugin' (snapshot version no longer exists).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <configuration>
           <cdapArtifacts>
             <parent>system:cdap-data-pipeline[4.2.0,6.0.0-SNAPSHOT)</parent>


### PR DESCRIPTION
Update version of 'cdap-maven-plugin' (snapshot version no longer exists).